### PR TITLE
Split config cmds

### DIFF
--- a/bin/commands/config.js
+++ b/bin/commands/config.js
@@ -11,7 +11,9 @@ const {
 
 module.exports = {
   command: "config <setting>",
-  desc: "Set configuration options",
+  desc: `Set configuration options
+  
+  usage: idea config [<options>]`,
   handler: async argv => {
     const { setting } = argv;
     switch (setting) {
@@ -38,8 +40,7 @@ module.exports = {
 
       case "topic":
         // TODO: rename directive to ...?
-        const directive = argv._[1] && argv._[1].trim();
-        if (directive === "set") {
+        if (argv.select === true) {
           await promptForTopic();
         } else {
           try {

--- a/bin/commands/config.js
+++ b/bin/commands/config.js
@@ -1,64 +1,6 @@
-const chalk = require("chalk");
-const Table = require("cli-table");
-const { conf, config } = require("../config");
-const { getTopic } = require("../api");
-const {
-  printError,
-  errorMsg,
-  successMsg,
-  promptForTopic
-} = require("../utils");
-
 module.exports = {
   command: "config <setting>",
-  desc: `Set configuration options
-  
-  usage: idea config [<options>]`,
-  handler: async argv => {
-    const { setting } = argv;
-    switch (setting) {
-      case "boardId":
-        const boardId = argv._[1];
-        if (boardId) {
-          conf.set("boardId", boardId);
-          successMsg(`boardId set to "${boardId}"`);
-        } else {
-          console.log(conf.get("boardId"));
-        }
-        break;
-
-      case "info":
-        console.log(`Config located at: ${conf.path}`);
-        const table = new Table({
-          head: ["Setting", "Value"]
-        });
-        Object.entries(config).forEach(([k, v]) => {
-          table.push([k, v || ""]);
-        });
-        console.log(table.toString());
-        break;
-
-      case "topic":
-        // TODO: rename directive to ...?
-        if (argv.select === true) {
-          await promptForTopic();
-        } else {
-          try {
-            const topic = await getTopic(config.topicId);
-            const { name, id } = topic.data;
-            console.log(chalk.green.bold(`Current topic:`));
-            console.log(`Name: ${name}`);
-            console.log(`Id: ${id}`);
-          } catch (err) {
-            printError(err);
-            process.exit();
-          }
-        }
-        break;
-
-      default:
-        errorMsg(chalk.red.bold(`Unknown setting "${setting}"`));
-        process.exit();
-    }
-  }
+  desc: `Set configuration options`,
+  builder: yargs => yargs.commandDir("config_commands"),
+  handler: _ => {}
 };

--- a/bin/commands/config_commands/board.js
+++ b/bin/commands/config_commands/board.js
@@ -1,0 +1,16 @@
+const { conf } = require("../../config");
+const { successMsg } = require("../../utils");
+
+module.exports = {
+  command: "board",
+  handler: argv => {
+    console.log(argv);
+    const boardId = argv._[2];
+    if (boardId) {
+      conf.set("boardId", boardId);
+      successMsg(`boardId set to "${boardId}"`);
+    } else {
+      console.log(conf.get("boardId"));
+    }
+  }
+};

--- a/bin/commands/config_commands/info.js
+++ b/bin/commands/config_commands/info.js
@@ -1,0 +1,16 @@
+const { conf, config } = require("../../config");
+const Table = require("cli-table");
+
+module.exports = {
+  command: "info",
+  handler: _ => {
+    console.log(`Config located at: ${conf.path}`);
+    const table = new Table({
+      head: ["Setting", "Value"]
+    });
+    Object.entries(config).forEach(([k, v]) => {
+      table.push([k, v || ""]);
+    });
+    console.log(table.toString());
+  }
+};

--- a/bin/commands/config_commands/topic.js
+++ b/bin/commands/config_commands/topic.js
@@ -1,0 +1,24 @@
+const chalk = require("chalk");
+const { config } = require("../../config");
+const { getTopic } = require("../../api");
+const { printError, promptForTopic } = require("../../utils");
+
+module.exports = {
+  command: "topic",
+  handler: async argv => {
+    if (argv.select === true) {
+      await promptForTopic();
+    } else {
+      try {
+        const topic = await getTopic(config.topicId);
+        const { name, id } = topic.data;
+        console.log(chalk.green.bold(`Current topic:`));
+        console.log(`Name: ${name}`);
+        console.log(`Id: ${id}`);
+      } catch (err) {
+        printError(err);
+        process.exit();
+      }
+    }
+  }
+};

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,16 +1,5 @@
 #!/usr/bin/env node
 
 const yargs = require("yargs");
-const ideaCmd = require("./commands/idea");
-const configCmd = require("./commands/config");
 
-/**
- * ask config topic // shows list of topics and prompts user to select one
- * ask config --unset topic
- * ask config info // outputs path to config file & existing config values
- * ask config board [value] // prints existing boardId value, or sets new one
- */
-
-// TODO: you should be able to call config command without having been prev authenticated
-
-yargs.command(ideaCmd).command(configCmd).argv;
+yargs.commandDir("commands").help().argv;

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
-const yargs = require("yargs");
-
-yargs.commandDir("commands").help().argv;
+require("yargs")
+  .commandDir("commands")
+  .demandCommand()
+  .help().argv;


### PR DESCRIPTION
Create modules for each config subcommand, rather than handling them via a `switch` statement in the main `config` command.